### PR TITLE
Add "navigator" to the list of globals

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ const globals = {
   global: false,
   Map: true,
   module: false,
+  navigator: false,
   process: false,
   Promise: true,
   requestAnimationFrame: true,


### PR DESCRIPTION
As seen in http://facebook.github.io/react-native/docs/geolocation.html, you have to use the `navigator` object to get a device's position: e.g., `navigator.geolocation.getCurrentPosition`.